### PR TITLE
fix: update github action to use value-dev

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -187,14 +187,14 @@ jobs:
         
     - name: Deploy controller for testing
       run: |
-        # Deploy the controller using Helm
+        # Deploy the controller using Helm with development values (local image)
         helm upgrade --install coredns-ingress-sync \
           ./helm/coredns-ingress-sync \
           --namespace coredns-ingress-sync \
           --create-namespace \
           --wait \
           --timeout 30s \
-          --set image.tag=latest \
+          --values ./helm/coredns-ingress-sync/values-dev.yaml \
           --set image.pullPolicy=Never
         
         # Wait for deployment with timeout and detailed logging


### PR DESCRIPTION
Tests were failing to deploy the coredns-ingres-sync controller as the default values file specifies the public image registry.
This instructs it to be deployed with the values-dev.yaml which overrides to use the locally built image name.