### PR TITLE
Update CoreDNS configuration instructions for safety

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -107,7 +107,8 @@ rewrite name exact web.app-staging.example.com ingress-nginx-controller.ingress-
 **Helm Values Configuration**:
 ```yaml
 coreDNS:
-  autoConfigure: true  # Enable automatic CoreDNS management
+  # IMPORTANT: Default is false for safety - must be explicitly enabled
+  autoConfigure: false  # Set to true to enable automatic CoreDNS management
   namespace: kube-system
   configMapName: coredns
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,20 @@ This has been tested to work with [ingress-nginx](https://github.com/kubernetes/
 ### Installation
 
 ```bash
-# Install from local chart
+# Basic installation (CoreDNS auto-configuration DISABLED by default)
 helm install coredns-ingress-sync ./helm/coredns-ingress-sync \
   --namespace coredns-ingress-sync \
   --create-namespace
 
-# Or install from GitHub Packages
+# Or install from GitHub Packages  
 helm install coredns-ingress-sync \
   oci://ghcr.io/rl-io/charts/coredns-ingress-sync \
   --version 0.1.0 \
   --namespace coredns-ingress-sync \
   --create-namespace
+
+# To enable automatic CoreDNS configuration, add:
+#   --set coreDNS.autoConfigure=true
 ```
 
 ### Verification
@@ -198,9 +201,29 @@ controller:
   targetCNAME: ingress-nginx-controller.ingress-nginx.svc.cluster.local.
 
 coreDNS:
+  # IMPORTANT: Set to true to enable automatic CoreDNS configuration
+  # Default is false for safety - no unexpected changes will be made
   autoConfigure: true
   namespace: kube-system
 ```
+
+**⚠️ Important**: By default, `coreDNS.autoConfigure` is set to `false` to prevent unexpected changes to your CoreDNS configuration. You must explicitly set it to `true` to enable automatic CoreDNS management:
+
+```bash
+# Enable automatic CoreDNS configuration
+helm install coredns-ingress-sync \
+  oci://ghcr.io/rl-io/charts/coredns-ingress-sync \
+  --set coreDNS.autoConfigure=true
+```
+
+When `autoConfigure=false`, the controller will:
+
+- ✅ Still watch for ingress changes and generate DNS rules
+- ✅ Create the dynamic ConfigMap with DNS configuration  
+- ❌ NOT modify CoreDNS Corefile or deployment
+- ❌ NOT automatically enable DNS resolution
+
+This allows you to inspect the generated configuration before applying it to CoreDNS.
 
 For detailed configuration options and examples, see [📋 Configuration Guide](docs/CONFIGURATION.md).
 
@@ -223,8 +246,8 @@ We welcome contributions! Please see the [Development Guide](docs/DEVELOPMENT.md
 
 ## Support
 
-- **🐛 Issues**: [GitHub Issues](https://github.com/your-org/coredns-ingress-sync/issues)
-- **💬 Discussions**: [GitHub Discussions](https://github.com/your-org/coredns-ingress-sync/discussions)
+- **🐛 Issues**: [GitHub Issues](https://github.com/rl-io/coredns-ingress-sync/issues)
+- **💬 Discussions**: [GitHub Discussions](https://github.com/rl-io/coredns-ingress-sync/discussions)
 - **📖 Documentation**: See the `docs/` directory for comprehensive guides
 
 ## License

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -33,8 +33,9 @@ controller:
 
 ```yaml
 coreDNS:
-  # Automatically configure CoreDNS (recommended)
-  autoConfigure: true
+  # Automatically configure CoreDNS
+  # IMPORTANT: Default is false for safety - set to true to enable
+  autoConfigure: false
   
   # CoreDNS namespace
   namespace: "kube-system"
@@ -42,6 +43,8 @@ coreDNS:
   # CoreDNS ConfigMap name
   configMapName: "coredns"
 ```
+
+**⚠️ Safety First**: By default, `autoConfigure` is `false` to prevent unexpected changes to your CoreDNS configuration. You must explicitly enable it.
 
 ### Resource Configuration
 
@@ -98,6 +101,7 @@ To watch multiple ingress classes, deploy multiple instances:
 ```bash
 # Install for nginx ingress class
 helm install coredns-ingress-sync-nginx ./helm/coredns-ingress-sync \
+  --set coreDNS.autoConfigure=true \
   --set controller.ingressClass=nginx \
   --set controller.dynamicConfigMap.name=coredns-nginx \
   --namespace coredns-ingress-sync \
@@ -105,6 +109,7 @@ helm install coredns-ingress-sync-nginx ./helm/coredns-ingress-sync \
 
 # Install for traefik ingress class
 helm install coredns-ingress-sync-traefik ./helm/coredns-ingress-sync \
+  --set coreDNS.autoConfigure=true \
   --set controller.ingressClass=traefik \
   --set controller.dynamicConfigMap.name=coredns-traefik \
   --set controller.targetCNAME=traefik.traefik.svc.cluster.local. \

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -249,6 +249,7 @@ kind load docker-image coredns-ingress-sync:latest --name coredns-test
 helm install coredns-ingress-sync ./helm/coredns-ingress-sync \
   --namespace coredns-ingress-sync \
   --create-namespace \
+  --set coreDNS.autoConfigure=true \
   --set image.tag=latest \
   --set image.pullPolicy=Never \
   --set controller.logLevel=debug

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -47,12 +47,14 @@ controller:
 
 ### Q: Can I disable the automatic CoreDNS configuration?
 
-A: Yes, set `coreDNS.autoConfigure: false` in your Helm values. You'll then need to manually add the import statement to your CoreDNS configuration:
+A: Yes, automatic CoreDNS configuration is disabled by default (`coreDNS.autoConfigure: false`). To enable automatic configuration, set:
 
 ```yaml
 coreDNS:
-  autoConfigure: false
+  autoConfigure: true
 ```
+
+When disabled, you'll need to manually add the import statement to your CoreDNS configuration.
 
 ### Q: How do I configure multiple replicas?
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -385,7 +385,8 @@ kubectl rollout restart deployment/coredns -n kube-system
 # 5. Reinstall controller
 helm install coredns-ingress-sync ./helm/coredns-ingress-sync \
   --namespace coredns-ingress-sync \
-  --create-namespace
+  --create-namespace \
+  --set coreDNS.autoConfigure=true
 ```
 
 ### Backup and Restore

--- a/helm/coredns-ingress-sync/README.md
+++ b/helm/coredns-ingress-sync/README.md
@@ -29,6 +29,7 @@ This Helm chart deploys the CoreDNS Dynamic Internal Ingress Controller, which a
 helm install my-dns-controller \
   oci://ghcr.io/rl-io/charts/coredns-ingress-sync \
   --version 0.1.0 \
+  --set coreDNS.autoConfigure=true \
   --set controller.targetCname="ingress-nginx-controller.ingress-nginx.svc.cluster.local."
 ```
 
@@ -41,6 +42,7 @@ cd coredns-ingress-sync
 
 # Install from local chart
 helm install my-dns-controller ./helm/coredns-ingress-sync \
+  --set coreDNS.autoConfigure=true \
   --set controller.targetCname="ingress-nginx-controller.ingress-nginx.svc.cluster.local."
 ```
 
@@ -57,6 +59,7 @@ helm repo update
 
 # Install the chart
 helm install my-dns-controller rl-io/coredns-ingress-sync \
+  --set coreDNS.autoConfigure=true \
   --set controller.targetCname="ingress-nginx-controller.ingress-nginx.svc.cluster.local."
 ```
 
@@ -91,9 +94,11 @@ helm install my-dns-controller rl-io/coredns-ingress-sync \
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `coreDNS.autoConfigure` | Automatically configure CoreDNS | `true` |
+| `coreDNS.autoConfigure` | Automatically configure CoreDNS | `false` |
 | `coreDNS.namespace` | CoreDNS namespace | `kube-system` |
 | `coreDNS.configMapName` | CoreDNS ConfigMap name | `coredns` |
+
+**Important**: By default, `coreDNS.autoConfigure` is `false` to prevent automatic changes to coreDNS. Set to `true` to enable automatic CoreDNS management.
 
 ### Resources Configuration
 

--- a/helm/coredns-ingress-sync/values-dev.yaml
+++ b/helm/coredns-ingress-sync/values-dev.yaml
@@ -20,4 +20,5 @@ controller:
   logLevel: "debug"
 
 coreDNS:
+  # Enable automatic CoreDNS configuration for development
   autoConfigure: true

--- a/helm/coredns-ingress-sync/values-production.yaml
+++ b/helm/coredns-ingress-sync/values-production.yaml
@@ -20,6 +20,7 @@ controller:
   logLevel: "info"
 
 coreDNS:
+  # Enable automatic CoreDNS configuration in production
   autoConfigure: true
 
 nodeSelector:

--- a/helm/coredns-ingress-sync/values.yaml
+++ b/helm/coredns-ingress-sync/values.yaml
@@ -50,7 +50,9 @@ affinity: {}
 # CoreDNS configuration
 coreDNS:
   # Automatically configure CoreDNS for dynamic DNS resolution
-  autoConfigure: true
+  # IMPORTANT: Set to true to enable automatic CoreDNS configuration
+  # When false, manual CoreDNS configuration is required
+  autoConfigure: false
   # Namespace where CoreDNS is deployed
   namespace: kube-system
   # ConfigMap name


### PR DESCRIPTION
Revise documentation to clarify that automatic CoreDNS configuration is disabled by default for safety. Include explicit instructions for enabling it and emphasize the importance of manual configuration when disabled.