### PR TITLE
fix(ci): add docker buildx setup to resolve cache export error

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -23,6 +23,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+        
     - name: Log in to Container Registry
       uses: docker/login-action@v3
       with:


### PR DESCRIPTION
## Problem
The Docker build workflow in `.github/workflows/build-push.yml` is failing with this error:
```
ERROR: failed to build: Cache export is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
```

This was happening because the workflow was trying to use GitHub Actions cache export (`cache-to: type=gha,mode=max`) without properly setting up the buildx driver that supports this feature.

## Solution
Added `docker/setup-buildx-action@v3` step before the Docker login to ensure we have a proper buildx driver that supports cache export functionality.

## Changes
- Added `- name: Set up Docker Buildx` step using `docker/setup-buildx-action@v3`
- This enables proper GitHub Actions cache export for Docker builds
- Resolves the cache driver compatibility issue

## Testing
This fix should resolve the failing Docker builds that were triggered via repository_dispatch from release-please. The workflow should now successfully build and push Docker images for releases.

## Impact
✅ Fixes Docker build failures for release automation  
✅ Enables proper caching for faster subsequent builds  
✅ No breaking changes to existing functionality