### PR TITLE
fix(helm): add proper Helm hooks for autoConfigure mode

### DIFF
--- a/helm/coredns-ingress-sync/templates/rbac.yaml
+++ b/helm/coredns-ingress-sync/templates/rbac.yaml
@@ -7,6 +7,12 @@ metadata:
   name: {{ include "coredns-ingress-sync.fullname" . }}-cluster
   labels:
     {{- include "coredns-ingress-sync.labels" . | nindent 4 }}
+  {{- if .Values.coreDNS.autoConfigure }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
@@ -24,6 +30,12 @@ metadata:
   name: {{ include "coredns-ingress-sync.fullname" . }}-cluster
   labels:
     {{- include "coredns-ingress-sync.labels" . | nindent 4 }}
+  {{- if .Values.coreDNS.autoConfigure }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -51,6 +63,12 @@ metadata:
   namespace: {{ $namespace }}
   labels:
     {{- include "coredns-ingress-sync.labels" $ | nindent 4 }}
+  {{- if $.Values.coreDNS.autoConfigure }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
@@ -63,6 +81,12 @@ metadata:
   namespace: {{ $namespace }}
   labels:
     {{- include "coredns-ingress-sync.labels" $ | nindent 4 }}
+  {{- if $.Values.coreDNS.autoConfigure }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -83,6 +107,12 @@ metadata:
   name: {{ include "coredns-ingress-sync.fullname" . }}-coredns
   labels:
     {{- include "coredns-ingress-sync.labels" . | nindent 4 }}
+  {{- if .Values.coreDNS.autoConfigure }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -102,6 +132,12 @@ metadata:
   name: {{ include "coredns-ingress-sync.fullname" . }}-coredns
   labels:
     {{- include "coredns-ingress-sync.labels" . | nindent 4 }}
+  {{- if .Values.coreDNS.autoConfigure }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -120,6 +156,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "coredns-ingress-sync.labels" . | nindent 4 }}
+  {{- if .Values.coreDNS.autoConfigure }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
@@ -138,6 +180,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "coredns-ingress-sync.labels" . | nindent 4 }}
+  {{- if .Values.coreDNS.autoConfigure }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm/coredns-ingress-sync/templates/serviceaccount.yaml
+++ b/helm/coredns-ingress-sync/templates/serviceaccount.yaml
@@ -5,20 +5,15 @@ metadata:
   name: {{ include "coredns-ingress-sync.serviceAccountName" . }}
   labels:
     {{- include "coredns-ingress-sync.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- if or .Values.serviceAccount.annotations .Values.coreDNS.autoConfigure }}
   annotations:
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if .Values.coreDNS.autoConfigure }}
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation
     {{- end }}
-  {{- else }}
-  {{- if .Values.coreDNS.autoConfigure }}
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-10"
-    "helm.sh/hook-delete-policy": before-hook-creation
-  {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
- Fix ServiceAccount template conditional logic for Helm hooks
- Add pre-install/pre-upgrade hooks to all RBAC resources when autoConfigure=true
- Ensures ServiceAccount and RBAC permissions exist before controller pod starts
- Fixes 'serviceaccount not found' error during upgrades with autoConfigure enabled
- Hook execution order: ServiceAccount (-10), ClusterRole/Role (-5), Bindings (-4)
- No hooks applied when autoConfigure=false to maintain simple deployment

Resolves deployment failures when enabling CoreDNS auto-configuration."