### PR TITLE
ci: derive Helm chart registry owner from repository context

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -62,24 +62,29 @@ jobs:
       run: |
         # Package the chart
         helm package helm/coredns-ingress-sync
-        
+
         echo "Packaged chart:"
         ls -la coredns-ingress-sync-*.tgz
+
+        # Owner of the repository (lowercased for OCI registry compatibility).
+        # Derived from the GitHub context so the chart publishes under whichever
+        # org/user owns the repo, even after a repository transfer.
+        OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
 
         # Get chart details
         CHART_FILE=$(ls coredns-ingress-sync-*.tgz | head -n1)
         echo "Chart file: $CHART_FILE"
-        
+
         # Push to GitHub Packages (OCI format)
         # Use charts subdirectory to avoid collision with Docker image
-        echo "Pushing chart to oci://${REGISTRY}/rl-io/charts..."
-        
+        echo "Pushing chart to oci://${REGISTRY}/${OWNER}/charts..."
+
         # Try the push with charts subdirectory to separate from Docker images
-        helm push "$CHART_FILE" oci://${REGISTRY}/rl-io/charts --debug || {
+        helm push "$CHART_FILE" oci://${REGISTRY}/${OWNER}/charts --debug || {
           echo "Push failed. Trying alternative URL format..."
-          helm push "$CHART_FILE" oci://${REGISTRY}/rl-io/helm-charts --debug || {
+          helm push "$CHART_FILE" oci://${REGISTRY}/${OWNER}/helm-charts --debug || {
             echo "Alternative format also failed. Trying with original format..."
-            helm push "$CHART_FILE" oci://${REGISTRY}/rl-io --debug
+            helm push "$CHART_FILE" oci://${REGISTRY}/${OWNER} --debug
           }
         }
         
@@ -88,12 +93,13 @@ jobs:
     - name: Verify chart availability
       run: |
         echo "Verifying chart was pushed successfully..."
+        OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
         # Try to show the chart (this will fail gracefully if not available)
-        helm show chart oci://${REGISTRY}/rl-io/charts/${CHART_NAME} || {
-          echo "Chart not found at oci://${REGISTRY}/rl-io/charts/${CHART_NAME}, trying other locations..."
-          helm show chart oci://${REGISTRY}/rl-io/helm-charts/${CHART_NAME} || {
+        helm show chart oci://${REGISTRY}/${OWNER}/charts/${CHART_NAME} || {
+          echo "Chart not found at oci://${REGISTRY}/${OWNER}/charts/${CHART_NAME}, trying other locations..."
+          helm show chart oci://${REGISTRY}/${OWNER}/helm-charts/${CHART_NAME} || {
             echo "Chart not found at helm-charts location, trying root..."
-            helm show chart oci://${REGISTRY}/rl-io/${CHART_NAME} || {
+            helm show chart oci://${REGISTRY}/${OWNER}/${CHART_NAME} || {
               echo "Chart verification failed, but push may have succeeded. Check the GitHub Packages page."
             }
           }


### PR DESCRIPTION
## Summary

Prepares the repository for a possible **org transfer** by removing the one CI coupling that would silently break on a move: the Helm release workflow hardcoded the chart's OCI registry namespace (`oci://ghcr.io/rl-io/...`).

This derives the owner from `${{ github.repository_owner }}` (lowercased for OCI compatibility) so the chart publishes under whichever org/user owns the repository — including after a transfer — with no further edits. **Behaviour is unchanged for the current owner.**

The Docker image workflow already uses `${{ github.repository }}`, so it needed no change.

## Why only this change

Only edits that are correct *both before and after* a transfer belong here. The remaining transfer items would break things while the repo still lives under the current owner, so they are intentionally **left for transfer time**:

- `CODEOWNERS` owner handle → new org team
- Go module path (`github.com/<owner>/...`) rename + imports — GitHub redirects keep `go get` working post-transfer
- README / docs / badge URLs — covered by GitHub redirects
- `CODECOV_TOKEN` re-link, GHCR package visibility, and the org "Allow GitHub Actions to create and approve pull requests" setting (needed by release-please) — all GitHub-side, not in the repo

## Testing

- `helm-release.yml` parses cleanly (`yq`).
- No remaining hardcoded owner in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)